### PR TITLE
fix: mockserver image overriding option

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevServicesMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevServicesMockServerProcessor.java
@@ -149,7 +149,8 @@ public class DevServicesMockServerProcessor {
             return null;
         }
 
-        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(DEFAULT_IMAGE));
+        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(DEFAULT_IMAGE))
+                .asCompatibleSubstituteFor("mockserver/mockserver");
 
         Supplier<DevServicesResultBuildItem.RunningDevService> defaultMockServerSupplier = () -> {
             QuarkusPortMockServerContainer container = new QuarkusPortMockServerContainer(dockerImageName,


### PR DESCRIPTION
**Problem**
When overriding mockserver image name following error is thrown
`"Failed to verify that image '[custom-docker-registry/mockserver/mockserver:5.15.0](http://custom-docker-registry/mockserver/mockserver:5.15.0)' is a compatible substitute for 'jamesdbloom/mockserver'. This generally means that you are trying to use an image that Testcontainers has not been designed to use. If this is deliberate, and if you are confident that the image is compatible, you should declare compatibility in code using the `asCompatibleSubstituteFor` method. 
**Solution**
Adding asCompatibleSubstituteFor("mockserver/mockserver") to make overriding mockserver image name possible
