### PR TITLE
fix(test): Support a changing environment for the MockClientServer injection

### DIFF
--- a/integration-tests/base/src/main/java/io/quarkiverse/mockserver/it/base/BaseRestController.java
+++ b/integration-tests/base/src/main/java/io/quarkiverse/mockserver/it/base/BaseRestController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -42,5 +43,11 @@ public class BaseRestController {
     public static class Data {
         public String key;
         public String value;
+    }
+
+    @GET
+    @Path("3")
+    public Response anotherEndpoint() {
+        return Response.ok().build();
     }
 }

--- a/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/TestNotUsingMockServerDevService.java
+++ b/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/TestNotUsingMockServerDevService.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mockserver.it.base;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.Map;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(TestNotUsingMockServerDevService.TestProfile.class)
+public class TestNotUsingMockServerDevService {
+    @Test
+    public void test200() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .get("/test/3")
+                .prettyPeek()
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    public static class TestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.mockserver.devservices.enabled", "false");
+        }
+    }
+}

--- a/test/src/main/java/io/quarkiverse/mockserver/test/MockServerTestResource.java
+++ b/test/src/main/java/io/quarkiverse/mockserver/test/MockServerTestResource.java
@@ -24,14 +24,25 @@ public class MockServerTestResource implements QuarkusTestResourceLifecycleManag
 
     @Override
     public void inject(TestInjector testInjector) {
-        testInjector.injectIntoFields(CLIENT,
-                new TestInjector.AnnotatedAndMatchesType(InjectMockServerClient.class, MockServerClient.class));
+        if (CLIENT != null) {
+            testInjector.injectIntoFields(CLIENT,
+                    new TestInjector.AnnotatedAndMatchesType(InjectMockServerClient.class, MockServerClient.class));
+        }
     }
 
     @Override
     public void setIntegrationTestContext(DevServicesContext context) {
         String host = context.devServicesProperties().get(MockServerConfig.CLIENT_HOST);
         String port = context.devServicesProperties().get(MockServerConfig.CLIENT_PORT);
-        CLIENT = new MockServerClient(host, Integer.parseInt(port));
+        if (host == null) {
+            host = "localhost";
+        }
+        if (port == null) {
+            CLIENT = null;
+        } else if (CLIENT == null ||
+                !CLIENT.remoteAddress().getHostName().equals(host) ||
+                CLIENT.remoteAddress().getPort() != Integer.parseInt(port)) {
+            CLIENT = new MockServerClient(host, Integer.parseInt(port));
+        }
     }
 }


### PR DESCRIPTION
I.e. if the devservice is temporarily deactivated, delete the instance and do not try to inject it.
If the hostname and or port have changed, recreate the client with new coordinates.

Fixes #177
