### PR TITLE
fix: NoClassDefFoundError

### DIFF
--- a/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
+++ b/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
@@ -17,19 +17,19 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class IssueTest extends AbstractTest {
 
-        @InjectMockServerClient
-        MockServerClient mockServerClient;
+    @InjectMockServerClient
+    MockServerClient mockServerClient;
 
-        @Test
-        public void testUpsertDoesNotThrowNoClassDefFoundError() {
-                mockServerClient.upsert(
-                                new Expectation(
-                                                request()
-                                                                .withPath("/issue-149")
-                                                                .withMethod("GET"))
-                                                .thenRespond(
-                                                                response()
-                                                                                .withStatusCode(200)
-                                                                                .withBody("Fixed!")));
-        }
+    @Test
+    public void testUpsertDoesNotThrowNoClassDefFoundError() {
+        mockServerClient.upsert(
+                new Expectation(
+                        request()
+                                .withPath("/issue-149")
+                                .withMethod("GET"))
+                        .thenRespond(
+                                response()
+                                        .withStatusCode(200)
+                                        .withBody("Fixed!")));
+    }
 }

--- a/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
+++ b/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mockserver.it.base;
+
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.mock.Expectation;
+
+import io.quarkiverse.mockserver.test.InjectMockServerClient;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Regression test for Issue #149: NoClassDefFoundError: Could not initialize
+ * class com.github.fge.jackson.JacksonUtils
+ */
+@QuarkusTest
+public class IssueTest extends AbstractTest {
+
+        @InjectMockServerClient
+        MockServerClient mockServerClient;
+
+        @Test
+        public void testUpsertDoesNotThrowNoClassDefFoundError() {
+                mockServerClient.upsert(
+                                new Expectation(
+                                                request()
+                                                                .withPath("/issue-149")
+                                                                .withMethod("GET"))
+                                                .thenRespond(
+                                                                response()
+                                                                                .withStatusCode(200)
+                                                                                .withBody("Fixed!")));
+        }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,18 @@
         <artifactId>mockserver-client-java</artifactId>
         <version>${mockserver-client.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-client-java</artifactId>
+        <version>${mockserver-client.version}</version>
+        <classifier>shaded</classifier>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -16,6 +16,7 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-client-java</artifactId>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.mockserver</groupId>


### PR DESCRIPTION
Fixes: #243 

This avoids class conflicts with Jackson loaders that are different.

I believe that, with the change to the shaded mockserver-client-java, it is no longer necessary to manually add the swagger-core and jackson-coreutils dependencies to the test scope.

references: 

https://medium.com/@nsready/resolving-version-conflict-in-java-dependencies-65b26822203b
https://www.mock-server.com/where/maven_central.html