### PR TITLE
chore(deps): Update Mockserver from 5.15 to 7.1

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevMockServerServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevMockServerServicesConfig.java
@@ -103,4 +103,20 @@ public interface DevMockServerServicesConfig {
     @WithName("config-dir")
     Optional<String> configDir();
 
+    /**
+     * If true (the default) when no matching expectation is found, and the host header of the request does not match
+     * MockServer's host, then MockServer attempts to proxy the request. If the upstream server is unreachable
+     * (connection refused, TLS error, timeout, etc.) a 502 Bad Gateway is returned. If no matching expectation is
+     * found and the request is not eligible for proxying, a 404 is returned.
+     * <p>
+     * If false when no matching expectation is found, and MockServer is not being used as a proxy, then MockServer
+     * always returns a 404 immediately.
+     *
+     * @see <a href="https://www.mock-server.com/mock_server/configuration_properties.html">mock-server properties
+     *      documentation</a>
+     */
+    @WithDefault("false")
+    @WithName("attempt-to-proxy-if-no-matching-expectation")
+    boolean attemptToProxyIfNoMatchingExpectation();
+
 }

--- a/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevServicesMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mockserver/devservices/DevServicesMockServerProcessor.java
@@ -50,7 +50,7 @@ public class DevServicesMockServerProcessor {
 
     private static final String DEFAULT_MOCKSERVER_CONTAINER_IMAGE = "mockserver/mockserver";
 
-    private static final String DEFAULT_MOCKSERVER_VERSION = "5.15.0";
+    private static final String DEFAULT_MOCKSERVER_VERSION = "7.3.0";
 
     private static final DockerImageName MOCKSERVER_IMAGE_NAME = DockerImageName.parse(DEFAULT_MOCKSERVER_CONTAINER_IMAGE)
             .withTag(DEFAULT_MOCKSERVER_VERSION);
@@ -218,6 +218,12 @@ public class DevServicesMockServerProcessor {
             if (devServicesConfig.reuse()) {
                 container.withReuse(true);
             }
+
+            // whether to deactivate attempts to redirect when non-matching
+            // default from configuration is false, because in tests, most users want a 404 when no request is matching
+            // without this, they would then get a 502 bad gateway
+            container.addEnv("MOCKSERVER_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION",
+                    Boolean.toString(devServicesConfig.attemptToProxyIfNoMatchingExpectation()));
 
             // start test-container
             container.start();

--- a/docs/modules/ROOT/pages/includes/quarkus-mockserver.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mockserver.adoc
@@ -227,6 +227,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mockserver_quarkus-mockserver-devservices-attempt-to-proxy-if-no-matching-expectation]] [.property-path]##link:#quarkus-mockserver_quarkus-mockserver-devservices-attempt-to-proxy-if-no-matching-expectation[`+++quarkus.mockserver.devservices.attempt-to-proxy-if-no-matching-expectation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mockserver.devservices.attempt-to-proxy-if-no-matching-expectation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If true (the default) when no matching expectation is found, and the host header of the request does not match MockServer's host, then MockServer attempts to proxy the request. If the upstream server is unreachable (connection refused, TLS error, timeout, etc.) a 502 Bad Gateway is returned. If no matching expectation is found and the request is not eligible for proxying, a 404 is returned.
+
+If false when no matching expectation is found, and MockServer is not being used as a proxy, then MockServer always returns a 404 immediately.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MOCKSERVER_DEVSERVICES_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MOCKSERVER_DEVSERVICES_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-mockserver_quarkus-mockserver-host]] [.property-path]##link:#quarkus-mockserver_quarkus-mockserver-host[`+++quarkus.mockserver.host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mockserver.host+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mockserver_quarkus.mockserver.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mockserver_quarkus.mockserver.adoc
@@ -227,6 +227,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mockserver_quarkus-mockserver-devservices-attempt-to-proxy-if-no-matching-expectation]] [.property-path]##link:#quarkus-mockserver_quarkus-mockserver-devservices-attempt-to-proxy-if-no-matching-expectation[`+++quarkus.mockserver.devservices.attempt-to-proxy-if-no-matching-expectation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mockserver.devservices.attempt-to-proxy-if-no-matching-expectation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If true (the default) when no matching expectation is found, and the host header of the request does not match MockServer's host, then MockServer attempts to proxy the request. If the upstream server is unreachable (connection refused, TLS error, timeout, etc.) a 502 Bad Gateway is returned. If no matching expectation is found and the request is not eligible for proxying, a 404 is returned.
+
+If false when no matching expectation is found, and MockServer is not being used as a proxy, then MockServer always returns a 404 immediately.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MOCKSERVER_DEVSERVICES_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MOCKSERVER_DEVSERVICES_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-mockserver_quarkus-mockserver-host]] [.property-path]##link:#quarkus-mockserver_quarkus-mockserver-host[`+++quarkus.mockserver.host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mockserver.host+++[]

--- a/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/BaseRestControllerTest.java
+++ b/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/BaseRestControllerTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
@@ -24,6 +25,11 @@ public class BaseRestControllerTest extends AbstractTest {
 
     @InjectMockServerClient
     MockServerClient mockServerClient;
+
+    @AfterEach
+    public void resetMockServerClient() {
+        mockServerClient.reset();
+    }
 
     @Test
     public void test200() {

--- a/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
+++ b/integration-tests/base/src/test/java/io/quarkiverse/mockserver/it/base/IssueTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mockserver.it.base;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.mock.Expectation;
@@ -19,6 +20,11 @@ public class IssueTest extends AbstractTest {
 
     @InjectMockServerClient
     MockServerClient mockServerClient;
+
+    @AfterEach
+    public void resetMockServerClient() {
+        mockServerClient.reset();
+    }
 
     @Test
     public void testUpsertDoesNotThrowNoClassDefFoundError() {

--- a/integration-tests/docker/src/test/java/io/quarkiverse/mockserver/it/docker/ExampleRestControllerTest.java
+++ b/integration-tests/docker/src/test/java/io/quarkiverse/mockserver/it/docker/ExampleRestControllerTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
@@ -24,6 +25,11 @@ public class ExampleRestControllerTest extends AbstractTest {
 
     @InjectMockServerClient
     MockServerClient mockServerClient;
+
+    @AfterEach
+    public void resetMockServerClient() {
+        mockServerClient.reset();
+    }
 
     @Test
     public void test200() {

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.33.1</quarkus.version>
     <testcontainers.mockserver.version>2.0.5</testcontainers.mockserver.version>
-    <mockserver-client.version>5.15.0</mockserver-client.version>
+    <mockserver-client.version>7.3.0</mockserver-client.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <surefire-plugin.version>3.5.6</surefire-plugin.version>
   </properties>
@@ -56,9 +56,8 @@
       </dependency>
       <dependency>
         <groupId>org.mock-server</groupId>
-        <artifactId>mockserver-client-java</artifactId>
+        <artifactId>mockserver-client-java-no-dependencies</artifactId>
         <version>${mockserver-client.version}</version>
-        <classifier>shaded</classifier>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -15,8 +15,7 @@
     </dependency>
     <dependency>
       <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-client-java</artifactId>
-      <classifier>shaded</classifier>
+      <artifactId>mockserver-client-java-no-dependencies</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.mockserver</groupId>


### PR DESCRIPTION
Switch to the new maven artifact coordinates.
Switch to 6.1.0 version of the docker image.
Deactivate attempts to proxying requests when they do not match.
Without this we started getting 502 instead of 404 in some tests.

I think the mockserver is not loading expectation from the
initialization path: opened an [issue](https://github.com/mock-server/mockserver-monorepo/issues/2358).

Fixes: #311